### PR TITLE
chore(release): update Cargo.toml version to 1.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,7 +2610,7 @@ checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "replex"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "replex"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This PR updates the Cargo.toml version to 1.0.9.