### PR TITLE
chore: update Cargo.toml version to 1.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2751,7 +2751,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "replex"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["replex-common"] }
 [package]
 name = "replex"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 
 [dependencies]
@@ -12,7 +12,7 @@ base32 = "0.4.0"
 # bincode = "1.3.3"
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
 bytes = "1.4.0"
-replex-common = { path = "replex-common" }
+replex-common = { path = "replex-common" , version = "1.0.11" }
 config = "0.14.0"
 # console-subscriber = "0.1.10"
 data-encoding = "2.4.0"


### PR DESCRIPTION
This PR updates the Cargo.toml version to 1.0.11.